### PR TITLE
Replaced terraform.workspace refs for project value using output variable in its place

### DIFF
--- a/terraform/modules/project/apis.tf
+++ b/terraform/modules/project/apis.tf
@@ -7,7 +7,7 @@ resource "google_project_service" "monitoring" {
   depends_on = [ 
     "google_project.project"
   ]
-  project = "${terraform.workspace}"
+  project = "${var.google_project}"
   service = "monitoring.googleapis.com"
 }
 
@@ -15,7 +15,7 @@ resource "google_project_service" "logging" {
   depends_on = [
     "google_project.project"
   ]
-  project = "${terraform.workspace}"
+  project = "${var.google_project}"
   service = "logging.googleapis.com"
 }
 


### PR DESCRIPTION
Cleaned up references in external modules to use the output variable in place of the terraform.workspace variable to clean up dependencies. 